### PR TITLE
Fix logs_daily_dimensions_mv extra columns

### DIFF
--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Tinybird CLI
-        run: curl -LsSf https://api.tinybird.co/static/install.sh | sh
+        run: curl https://tinybird.co | sh
       - name: Authenticate
         run: tb auth --host https://api.europe-west2.gcp.tinybird.co --token ${{ secrets.TB_ADMIN_TOKEN }}
       - name: Deploy project

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -17,7 +17,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Tinybird CLI
         run: curl https://tinybird.co | sh
-      - name: Authenticate
-        run: tb auth --host https://api.europe-west2.gcp.tinybird.co --token ${{ secrets.TB_ADMIN_TOKEN }}
       - name: Deploy project
-        run: tb --cloud deploy
+        run: tb --cloud --host https://api.europe-west2.gcp.tinybird.co --token ${{ secrets.TB_ADMIN_TOKEN }} deploy

--- a/.github/workflows/tinybird-ci.yml
+++ b/.github/workflows/tinybird-ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Tinybird CLI
-        run: curl -LsSf https://api.tinybird.co/static/install.sh | sh
+        run: curl https://tinybird.co | sh
       - name: Build project
         run: tb build
       - name: Test project

--- a/.github/workflows/tinybird-ci.yml
+++ b/.github/workflows/tinybird-ci.yml
@@ -29,3 +29,5 @@ jobs:
         run: tb build
       - name: Test project
         run: tb test run
+      - name: Deploy check
+        run: tb --cloud --host https://api.europe-west2.gcp.tinybird.co --token ${{ secrets.TB_ADMIN_TOKEN }} deploy --check

--- a/tinybird/datasources/logs_daily_dimensions.datasource
+++ b/tinybird/datasources/logs_daily_dimensions.datasource
@@ -16,4 +16,7 @@ SCHEMA >
 ENGINE "AggregatingMergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(date)"
 ENGINE_SORTING_KEY "date, environment, service, level, request_method, status_code, host, request_path, user_agent"
-ENGINE_PRIMARY_KEY "date, environment, service, level" 
+ENGINE_PRIMARY_KEY "date, environment, service, level"
+
+FORWARD_QUERY >
+    SELECT *

--- a/tinybird/datasources/logs_daily_timeseries.datasource
+++ b/tinybird/datasources/logs_daily_timeseries.datasource
@@ -19,3 +19,6 @@ ENGINE "AggregatingMergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(date)"
 ENGINE_SORTING_KEY "date, environment, service, level, request_method, status_code, request_path, user_agent"
 ENGINE_PRIMARY_KEY "date, environment, service, level"
+
+FORWARD_QUERY >
+    SELECT *

--- a/tinybird/datasources/logs_range_15m.datasource
+++ b/tinybird/datasources/logs_range_15m.datasource
@@ -10,3 +10,6 @@ ENGINE "AggregatingMergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(start_ts)"
 ENGINE_SORTING_KEY "start_ts, end_ts, environment, service, level"
 ENGINE_PRIMARY_KEY "start_ts, end_ts, environment"
+
+FORWARD_QUERY >
+    SELECT *

--- a/tinybird/materializations/logs_daily_dimensions_mv.pipe
+++ b/tinybird/materializations/logs_daily_dimensions_mv.pipe
@@ -13,14 +13,7 @@ SQL >
         request_path,
         user_agent,
         host,
-        countState() as count,
-        avgState(response_time) as avg_response_time,
-        sumState(response_time) as sum_response_time,
-        minState(response_time) as min_response_time,
-        maxState(response_time) as max_response_time,
-        quantileState(0.5)(response_time) as median_response_time,
-        quantileState(0.9)(response_time) as p90_response_time,
-        quantileState(0.99)(response_time) as p99_response_time
+        countState() as count
     FROM logs
     GROUP BY
         date,


### PR DESCRIPTION
We have added a new check validating MV and target DS have the same columns and it's failing:

```
$ tb build

» Building project...

Error in materialized node 'aggregate_dimensions' from pipe 'logs_daily_dimensions_mv': Materialized view target data source columns do not match the materialized view query columns.Materialized view query columns: max_response_time, level, request_path, min_response_time, sum_response_time, p90_response_time, date, median_response_time, environment, count, p99_response_time, status_code, service, avg_response_time, request_method, user_agent, host.Target data source columns: level, request_path, date, environment, count, status_code, service, request_method, user_agent, host

✗ Build failed
```